### PR TITLE
Enhance homepage sections and financial tables

### DIFF
--- a/src/components/FinancialTable.ts
+++ b/src/components/FinancialTable.ts
@@ -66,12 +66,20 @@ export function createFinancialSheet(sheet: FinancialSheet): HTMLElement {
   const tbody = document.createElement('tbody');
   table.appendChild(tbody);
 
-  sheet.rows.forEach(row => {
+  sheet.rows.forEach((row, rowIndex) => {
     const tr = document.createElement('tr');
     row.values.forEach((val, colIndex) => {
       const td = document.createElement('td');
       td.textContent = val;
-      td.className = colIndex > 0 ? 'number' : '';
+      if (row.editable !== false && colIndex > 0) {
+        td.contentEditable = 'true';
+        td.classList.add('editable');
+        td.addEventListener('input', () => {
+          row.values[colIndex] = td.textContent || '';
+          updateAllCalculations();
+        });
+      }
+      if (colIndex > 0) td.classList.add('number');
       tr.appendChild(td);
     });
     tbody.appendChild(tr);

--- a/src/pages/home.ts
+++ b/src/pages/home.ts
@@ -20,7 +20,7 @@ export function renderHome(root: HTMLElement | null) {
     id: "concept",
     title: "Un concept inédit",
     content: `
-      <div class="img-placeholder"></div>
+      <img src="/image-01.jpg" alt="Concept" />
       <p>
         METBrandVoice est la première compétition artistique dédiée à la voix-off, mettant la publicité au cœur du spectacle. Chaque prestation est jugée en direct par le public.
         Ici, la publicité devient émotion, performance et engagement ! Les candidats s'affrontent sur scène, interprétant des textes publicitaires devant un public en immersion totale.
@@ -45,8 +45,9 @@ export function renderHome(root: HTMLElement | null) {
   ];
   const cards = valeurs.map(val => createCard(val));
   const valeursContent = [] as HTMLElement[];
-  const imgVal = document.createElement('div');
-  imgVal.className = 'img-placeholder';
+  const imgVal = document.createElement('img');
+  imgVal.src = '/image-02.jpg';
+  imgVal.alt = 'Valeurs';
   valeursContent.push(imgVal, createGrid(cards));
   root.appendChild(createSection({
     id: "valeurs",
@@ -63,8 +64,9 @@ export function renderHome(root: HTMLElement | null) {
       <li><b>Public :</b> devenez jury, votez en direct, pariez, gagnez et vivez la pub autrement.</li>
     </ul>
   `;
-  const cibleImg = document.createElement('div');
-  cibleImg.className = 'img-placeholder';
+  const cibleImg = document.createElement('img');
+  cibleImg.src = '/image-03.jpg';
+  cibleImg.alt = 'Cible';
   root.appendChild(createSection({
     id: "pourqui",
     title: "À qui s'adresse METBrandVoice ?",

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -119,15 +119,15 @@ a:hover { text-decoration: underline; }
 
 /* Section */
 .section {
-  max-width: 900px;
-  margin: 2rem auto;
-  padding: 2.5rem 2rem;
-  background: #111111ee;
-  border-radius: var(--radius-xl);
-  box-shadow: var(--shadow-lg);
+  width: 100%;
+  padding: 3.5rem 2rem;
+  background: #111;
   opacity: 0;
   transform: translateY(40px);
   transition: opacity 0.6s ease, transform 0.6s ease;
+}
+.section:nth-of-type(even) {
+  background: #151515;
 }
 .section.visible {
   opacity: 1;
@@ -195,7 +195,25 @@ form#contactForm input:focus, form#contactForm textarea:focus {
   font-size: 1rem;
 }
 
-.financial-table td, .financial-table th {
+.financial-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+.financial-table th,
+.financial-table td {
+  padding: 0.6rem 1rem;
+  border: 1px solid #2b2b2b;
   min-width: 90px;
   vertical-align: middle;
+}
+.financial-table tbody tr:nth-child(odd) {
+  background: #202020;
+}
+.financial-table td.editable {
+  background: #262626;
+  cursor: text;
+}
+.financial-table tr:hover td {
+  background: #2f2f2f;
 }


### PR DESCRIPTION
## Summary
- replace placeholder divs with real images on homepage
- make sections full width with alternating backgrounds
- improve look and interactivity of financial tables

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68482f89db0c83308b046083b9d5bc5f